### PR TITLE
increase threshold for liveness probe

### DIFF
--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -317,12 +317,18 @@ spec:
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/csi.civo.com/csi.sock"
             - "--health-port=9809"
             - "--timeout=30s"
+          ports:
+          - containerPort: 9809
+            name: healthz
           livenessProbe:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 10
+            successThreshold: 1
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/deploy/kubernetes/05_node.yaml
+++ b/deploy/kubernetes/05_node.yaml
@@ -41,12 +41,18 @@ spec:
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/csi.civo.com/csi.sock"
             - "--health-port=9809"
             - "--timeout=30s"
+          ports:
+          - containerPort: 9809
+            name: healthz
           livenessProbe:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 10
+            successThreshold: 1
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
it seems the `healthz` port definition used in the `livenessProbe` is missing and just adding it, the parameters provided are too strict to let the health check to be successful so the `csi` pods go in `Crash Loop Backoff`.
So we need to make these params less strict to let the livenessProbe work correctly.

This approach has been test in a k3s cluster on Civo.