### PR TITLE
update version of csi to fix a known issue

### DIFF
--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -310,7 +310,7 @@ spec:
         operator: Exists
       containers:
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/kubernetes/05_node.yaml
+++ b/deploy/kubernetes/05_node.yaml
@@ -34,7 +34,7 @@ spec:
         operator: Exists
       containers:
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
On the long run, the csi pods suffer the issue presented for the version v2.5.0 of the image **k8s.gcr.io/sig-storage/csi-node-driver-registrar** as reported in the known issue: https://github.com/kubernetes-csi/node-driver-registrar/issues/188
The version v2.5.1 should fix the problem.
Tested that prevents the restarts on a real k3s cluster for more than half an hour.
