### PR TITLE
Set driver version in the binary based on release version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN go mod verify
 RUN find .
 
 # Build the binary.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X github.com/civo/civo-csi/driver.CSIVersion=${VERSION}" -o /app/civo-csi
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X github.com/civo/civo-csi/pkg/driver.Version=${VERSION}" -o /app/civo-csi
 
 
 ############################

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"os"
 	"os/signal"
 	"strings"
@@ -13,9 +14,19 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var (
+	versionInfo = flag.Bool("version", false, "Print the driver version")
+)
+
 func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	flag.Parse()
+	if *versionInfo {
+		log.Info().Str("version", driver.Version).Msg("CSI driver")
+		return
+	}
 
 	apiURL := strings.TrimSpace(os.Getenv("CIVO_API_URL"))
 	apiKey := strings.TrimSpace(os.Getenv("CIVO_API_KEY"))

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -17,14 +17,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-// CSIVersion is the version of the csi to set in the User-Agent header
-var CSIVersion = "dev"
-
 // Name is the name of the driver
 const Name string = "Civo CSI Driver"
 
-// Version is the current release of the driver
-const Version string = "0.0.1"
+// Version is the current version of the driver to set in the User-Agent header
+var Version string = "0.0.1"
 
 // DefaultVolumeSizeGB is the default size in Gigabytes of an unspecified volume
 const DefaultVolumeSizeGB int = 10


### PR DESCRIPTION
## WHAT

The release version has been modified to be mappable to the binary. 
Additionally, a flag to output the version information has been added. 
This allows the version information to be checked without making an RPC call.

## WHY

The version information of binary is incorrect. (The value returned by the RPC will be `0.0.1`.) 


## FYI

This PR has been tested using the following methods.

1. Docker build
```sh
$ make VERSION=v1.10.4 docker
```

2. Run docker contianer 
This version will be returned by RPC

```sh
$ docker run --rm {IMAGE_ID} --version
7:08AM INF CSI driver version=v1.10.4
```