### PR TITLE
Fix errors in existing Unit Tests on Local environment

### DIFF
--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           go-version: "^1.15"
       - name: Run tests
-        run: go test ./main_test.go
+        run: go test ./...
       - name: Run vetting/linting checks
         run: go vet ./...
   build:

--- a/pkg/driver/node_server_test.go
+++ b/pkg/driver/node_server_test.go
@@ -3,6 +3,7 @@ package driver_test
 import (
 	"context"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/civo/civo-csi/pkg/driver"
@@ -115,10 +116,12 @@ func TestNodePublishVolume(t *testing.T) {
 		hotPlugger := &driver.FakeDiskHotPlugger{}
 		d.DiskHotPlugger = hotPlugger
 
+		targetPath := path.Join(t.TempDir(), "some-path")
+
 		_, err := d.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
 			VolumeId:          "volume-1",
 			StagingTargetPath: "/mnt/my-target",
-			TargetPath:        "/var/lib/kubelet/some-path",
+			TargetPath:        targetPath,
 			VolumeCapability: &csi.VolumeCapability{
 				AccessType: &csi.VolumeCapability_Mount{},
 				AccessMode: &csi.VolumeCapability_AccessMode{
@@ -128,7 +131,7 @@ func TestNodePublishVolume(t *testing.T) {
 		})
 		assert.Nil(t, err)
 
-		mounted, _ := d.DiskHotPlugger.IsMounted("")
+		mounted, _ := d.DiskHotPlugger.IsMounted(targetPath)
 		assert.True(t, mounted)
 	})
 }
@@ -144,13 +147,15 @@ func TestNodeUnpublishVolume(t *testing.T) {
 		}
 		d.DiskHotPlugger = hotPlugger
 
+		targetPath := path.Join(t.TempDir(), "some-path")
+
 		_, err := d.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
 			VolumeId:   "volume-1",
-			TargetPath: "/var/lib/kubelet/some-path",
+			TargetPath: targetPath,
 		})
 		assert.Nil(t, err)
 
-		mounted, _ := d.DiskHotPlugger.IsMounted("/var/lib/kubelet/some-path")
+		mounted, _ := d.DiskHotPlugger.IsMounted(targetPath)
 		assert.False(t, mounted)
 	})
 }


### PR DESCRIPTION
## WHAT

I fixed the errors in the existing tests. 
Additionally, the driver tests were not running on CI, so I modified the actions workflow to enable them. This ensures that the existing driver test code will now run on CI.

## WHY

When I run all existing tests in the local environment, the following error occurred. Since I not sure whether the previous driver code was working properly, I have investigated. Upon investigation, I concluded that it was necessary to modify the only test code.

```
❯ go clean -testcache && go test ./...
ok  	github.com/civo/civo-csi	70.094s
ok  	github.com/civo/civo-csi/e2e	0.006s
{"level":"info","api_url":"https://civo-api.example.com","region":"TEST1","namespace":"default","cluster_id":"12345678","socketFilename":"unix:///var/lib/kubelet/plugins/civo-csi/csi.sock","user_agent":"civo-csi","time":"2024-11-07T18:06:02+09:00","message":"Created a new driver"}
--- FAIL: TestNodePublishVolume (0.00s)
    --- FAIL: TestNodePublishVolume/Bind-mount_the_volume_from_the_general_mount_point_in_to_the_container (0.00s)
        node_server_test.go:129:
            	Error Trace:	/xxx/go/src/github.com/civo/civo-csi/pkg/driver/node_server_test.go:129
            	Error:      	Expected nil, but got: &fs.PathError{Op:"mkdir", Path:"/var/lib/kubelet", Err:0xd}
            	Test:       	TestNodePublishVolume/Bind-mount_the_volume_from_the_general_mount_point_in_to_the_container
        node_server_test.go:132:
            	Error Trace:	/xxx/go/src/github.com/civo/civo-csi/pkg/driver/node_server_test.go:132
            	Error:      	Should be true
            	Test:       	TestNodePublishVolume/Bind-mount_the_volume_from_the_general_mount_point_in_to_the_container
FAIL
FAIL	github.com/civo/civo-csi/pkg/driver	10.012s
FAIL
```
↑ Error due to permissions when creating a folder in the local environment.

## FYI

:warning:  This change focuses on fixing existing unit test error, not adding new ones. 
While additional test cases will be considered in the future, I modified the current tests were not running successfully in both **local** and **CI** environments.

- The following is the result of all unit test on Local
```
❯ go clean -testcache && go test ./...
ok  	github.com/civo/civo-csi	70.093s
ok  	github.com/civo/civo-csi/e2e	0.006s
ok  	github.com/civo/civo-csi/pkg/driver	10.012s
```
- The following is the result of all unit test on CI
  - https://github.com/civo/civo-csi/actions/runs/11718701440/job/32640683855
