### PR TITLE
Add proper error handling and remove unnecessary variable definition

### DIFF
--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -107,7 +107,7 @@ func TestMain(m *testing.M) {
 	}
 
 	controller.Spec.Template.Spec.Containers[3].Image = Image
-	e2eTest.tenantClient.Update(context.TODO(), controller)
+	err = e2eTest.tenantClient.Update(context.TODO(), controller)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -120,7 +120,7 @@ func TestMain(m *testing.M) {
 		log.Panic(err)
 	}
 
-	e2eTest.tenantClient.Update(context.TODO(), csiDS)
+	err = e2eTest.tenantClient.Update(context.TODO(), csiDS)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -600,14 +600,12 @@ func (d *Driver) ListSnapshots(context.Context, *csi.ListSnapshotsRequest) (*csi
 }
 
 func getVolSizeInBytes(capRange *csi.CapacityRange) (int64, error) {
-	var bytes int64
-
 	if capRange == nil {
 		return int64(DefaultVolumeSizeGB) * BytesInGigabyte, nil
 	}
 
 	// Volumes can be of a flexible size, but they must specify one of the fields, so we'll use that
-	bytes = capRange.GetRequiredBytes()
+	bytes := capRange.GetRequiredBytes()
 	if bytes == 0 {
 		bytes = capRange.GetLimitBytes()
 	}


### PR DESCRIPTION
## WHAT

I fixed an small issue where errors were not being handled correctly in the test code. 
Additionally, I removed an unnecessary variable definition.

## WHY

There were parts of the test code where errors were being handled, but no errors were assigned.
I believe this needs to be fixed.
- e.g.) `./e2e/suite_test.go:104-113`
  - we need to assign the result of the `e2eTest.tenantClient.Update`  method to `err` variable
```

err = e2eTest.tenantClient.Get(context.TODO(), client.ObjectKey{Namespace: "kube-system", Name: "civo-csi-controller"}, controller)
if err != nil {
	log.Panic(err)
}

controller.Spec.Template.Spec.Containers[3].Image = Image

e2eTest.tenantClient.Update(context.TODO(), controller) <- we need to assign result to err variable
if err != nil {
	log.Panic(err)
}
```

I also found sections where the code worked correctly without the variable definition, so I removed it.

## FYI

- The following is the result of all unit test on Local environment
```sh
❯ go clean -testcache && go test ./...
ok  	github.com/civo/civo-csi	70.103s
ok  	github.com/civo/civo-csi/e2e	0.007s
ok  	github.com/civo/civo-csi/pkg/driver	10.013s
```

- The following is the result of all unit test on CI environment
  - https://github.com/civo/civo-csi/actions/runs/11773981531/job/32791775537