### PR TITLE
feat: add ListSnapshots RPC

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -630,24 +630,34 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	sourceVolumeID := req.GetSourceVolumeId()
 
 	if req.GetStartingToken() != "" {
-		log.Error().Msgf("Pagination not supported")
-		return nil, status.Errorf(codes.Aborted, "%v not supported", "starting-token")
+		log.Error().Msg("ListSnapshots RPC received a Starting token, but pagination is not supported. Ensure the request does not include a starting token.")
+		return nil, status.Error(codes.Aborted, "starting-token not supported") 
 	}
 
 	// case 1: SnapshotId is not empty, return snapshots that match the snapshot id
 	if len(snapshotID) != 0 {
-		log.Debug().Msgf("Fetching snapshot with ID %v", snapshotID)
+		log.Debug().
+			Str("snapshot_id", snapshotID).
+			Msg("Fetching snapshot")
 
 		// Retrieve a specific snapshot by ID
 		// Todo: GetSnapshot to be implemented in civogo
 		// Todo: Un-comment post client implementation
 		// snapshot, err := d.CivoClient.GetSnapshot(snapshotID)
 		// if err != nil {
-		// 	log.Error().Err(err).Msgf("No snapshot found matching the ID %v", snapshotID)
-		// 	if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") {
-		// 		return &csi.ListSnapshotsResponse{}, nil
-		// 	}
-		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshot %v: %v", snapshotID, err)
+		// Todo: DatabaseSnapshotNotFoundError & DiskSnapshotNotFoundError are placeholders, it's still not clear what error will be returned by API (awaiting implementation - WIP)
+		// if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") || 
+		// 	strings.Contains(err.Error(), "DiskSnapshotNotFoundError") {
+		// 	log.Info().
+		// 		Str("snapshot_id", snapshotID).
+		// 		Msg("ListSnapshots: no snapshot found, returning with success")
+		// 	return &csi.ListSnapshotsResponse{}, nil
+		// }
+		// 	log.Error().  
+		// 		Err(err).
+        // 		Str("snapshot_id", snapshotID).  
+        // 		Msg("Failed to list snapshot from Civo API") 
+		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshot %q: %v", snapshotID, err)
 		// }
 		// return &csi.ListSnapshotsResponse{
 		//     Entries: []*csi.ListSnapshotsResponse_Entry{convertSnapshot(snapshot)},
@@ -660,8 +670,11 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 
 		// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
 		// if err != nil{
-		//     log.Error().Err(err).Msgf("Failed to list snapshots for volume %v", sourceVolumeID)
-		//     return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %v: %v", sourceVolumeID, err)
+		// 	log.Error().
+		// 		Err(err).
+		// 		Str("source_volume_id", sourceVolumeID).
+		// 		Msg("Failed to list snapshots for volume")
+		//     return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %q: %v", sourceVolumeID, err)
 		// }
 
 		// entries := []*csi.ListSnapshotsResponse_Entry{}
@@ -683,7 +696,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
 	// if err != nil{
 	//     log.Error().Err(err).Msg("Failed to list snapshots from Civo API")
-	//     return nil, status.Errorf(codes.Internal, "failed to list snapshots from Civo API %v", err)
+	//     return nil, status.Errorf(codes.Internal, "failed to list snapshots from Civo API: %v", err)
 	// }
 
 	// sort.Slice(snapshots, func(i, j int) bool {

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -622,8 +622,84 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ListSnapshots is part of implementing Snapshot & Restore functionality, but we don't support that
-func (d *Driver) ListSnapshots(context.Context, *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+// ListSnapshots retrieves a list of existing snapshots as part of the Snapshot & Restore functionality.
+func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+	log.Info().Msg("Request: ListSnapshots")
+
+	snapshotID := req.GetSnapshotId()
+	sourceVolumeID := req.GetSourceVolumeId()
+
+	if req.GetStartingToken() != "" {
+		log.Error().Msgf("Pagination not supported")
+		return nil, status.Errorf(codes.Aborted, "%v not supported", "starting-token")
+	}
+
+	// case 1: SnapshotId is not empty, return snapshots that match the snapshot id
+	if len(snapshotID) != 0 {
+		log.Debug().Msgf("Fetching snapshot with ID %v", snapshotID)
+
+		// Retrieve a specific snapshot by ID
+		// Todo: GetSnapshot to be implemented in civogo
+		// Todo: Un-comment post client implementation
+		// snapshot, err := d.CivoClient.GetSnapshot(snapshotID)
+		// if err != nil {
+		// 	log.Error().Err(err).Msgf("No snapshot found matching the ID %v", snapshotID)
+		// 	if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") {
+		// 		return &csi.ListSnapshotsResponse{}, nil
+		// 	}
+		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshot %v: %v", snapshotID, err)
+		// }
+		// return &csi.ListSnapshotsResponse{
+		//     Entries: []*csi.ListSnapshotsResponse_Entry{convertSnapshot(snapshot)},
+		// }, nil
+	}
+
+	// case 2: Retrieve snapshots by source volume ID
+	if len(sourceVolumeID) != 0 {
+		log.Debug().Msgf("Fetching snapshots for volume ID %v", sourceVolumeID)
+
+		// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
+		// if err != nil{
+		//     log.Error().Err(err).Msgf("Failed to list snapshots for volume %v", sourceVolumeID)
+		//     return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %v: %v", sourceVolumeID, err)
+		// }
+
+		// entries := []*csi.ListSnapshotsResponse_Entry{}
+		// for _, snapshot := range snapshots {
+		//     if snapshot.VolID == sourceVolumeID {
+		//         entries = append(entries, convertSnapshot(snapshot))
+		//     }
+		// }
+
+		// return &csi.ListSnapshotsResponse{
+		//     Entries: entries,
+		// }, nil
+	}
+
+	log.Debug().Msg("Fetching all snapshots")
+
+	// case 3: Retrieve all snapshots if no filters are provided
+	// Todo: un-comment post client(civogo) implementation
+	// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
+	// if err != nil{
+	//     log.Error().Err(err).Msg("Failed to list snapshots from Civo API")
+	//     return nil, status.Errorf(codes.Internal, "failed to list snapshots from Civo API %v", err)
+	// }
+
+	// sort.Slice(snapshots, func(i, j int) bool {
+	//     return snapshots[i].Id < snapshots[j].Id
+	// })
+
+	// entries := []*csi.ListSnapshotsResponse_Entry{}
+	// for _, snap := range snapshots {
+	//     entries = append(entries, convertSnapshot(snap))
+	// }
+
+	// log.Info().Msgf("Successfully listed snapshots. Total snapshots: %d", len(entries))
+
+	// return &csi.ListSnapshotsResponse{
+	//     Entries:   entries,
+	// }, nil
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
@@ -640,3 +716,17 @@ func getVolSizeInBytes(capRange *csi.CapacityRange) (int64, error) {
 
 	return bytes, nil
 }
+
+// Todo: Un-comment post client implementation is complete
+// Todo: Snapshot to be defined in civogo
+// func convertSnapshot(snap *civogo.Snapshot) *csi.ListSnapshotsResponse_Entry {
+//     return &csi.ListSnapshotsResponse_Entry{
+//         Snapshot: &csi.Snapshot{
+//             SnapshotId:     snap.Id,
+//             SourceVolumeId: snap.VolID,
+//             CreationTime:   snap.CreationTime,
+//             SizeBytes:      snap.SizeBytes,
+//             ReadyToUse:     snap.ReadyToUse,
+//         },
+//     }
+// }

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -719,6 +719,7 @@ func getVolSizeInBytes(capRange *csi.CapacityRange) (int64, error) {
 
 // Todo: Un-comment post client implementation is complete
 // Todo: Snapshot to be defined in civogo
+// convertSnapshot function converts a civogo.Snapshot object(API response) into a CSI ListSnapshotsResponse_Entry
 // func convertSnapshot(snap *civogo.Snapshot) *csi.ListSnapshotsResponse_Entry {
 //     return &csi.ListSnapshotsResponse_Entry{
 //         Snapshot: &csi.Snapshot{

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -630,7 +630,8 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	sourceVolumeID := req.GetSourceVolumeId()
 
 	if req.GetStartingToken() != "" {
-		log.Error().Msg("ListSnapshots RPC received a Starting token, but pagination is not supported. Ensure the request does not include a starting token.")
+		log.Error().
+		Msg("ListSnapshots RPC received a Starting token, but pagination is not supported. Ensure the request does not include a starting token.")
 		return nil, status.Error(codes.Aborted, "starting-token not supported") 
 	}
 
@@ -666,7 +667,10 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 
 	// case 2: Retrieve snapshots by source volume ID
 	if len(sourceVolumeID) != 0 {
-		log.Debug().Msgf("Fetching snapshots for volume ID %v", sourceVolumeID)
+		log.Debug().
+			Str("operation", "list_snapshots").
+			Str("source_volume_id", sourceVolumeID).
+			Msg("Fetching volume snapshots")
 
 		// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
 		// if err != nil{
@@ -708,7 +712,9 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	//     entries = append(entries, convertSnapshot(snap))
 	// }
 
-	// log.Info().Msgf("Successfully listed snapshots. Total snapshots: %d", len(entries))
+	// log.Info().
+	// 	Int("total_snapshots", len(entries)).
+	// 	Msg("Snapshots listed successfully")
 
 	// return &csi.ListSnapshotsResponse{
 	//     Entries:   entries,


### PR DESCRIPTION
This PR implements the `ListSnapshots` RPC method as part of the CSI Driver's Snapshot & Restore functionality. It handle various cases for listing snapshots,

**Case 1:** **Fetch by Snapshot ID**

1. Retrieves a specific snapshot by its ID.
2. If the snapshot is not found(a successful search), returns an empty response instead of an error.
```Go
if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") {
	return &csi.ListSnapshotsResponse{}, nil
}
```
3. Returns an error only when, it encounters an internal error while retrieving the snapshot.
```Go
return nil, status.Errorf(codes.Internal, "failed to list snapshot %v: %v", snapshotID, err)
```

**Case 2: Fetch by Source Volume ID**

1. Lists snapshots associated with a specific source volume.

**Case 3: Fetch All Snapshots**

1. Retrieves all snapshots if no specific filters (snapshot ID or source volume ID) are provided.

The results are sorted and returned.
_Reason: To make the order deterministic_

> Note: for now I have commented out some parts of the code, as it requires some implementations on the client side.