### PR TITLE
Add logic to create volume from volumecontentsource

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -103,7 +103,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	// 	}
 	// 	snapshot := volSource.GetSnapshot()
 	// 	if snapshot == nil {
-	// 		return nil, status.Error(codes.InvalidArgument, "failed to get snapshot from the volumeContentSource")
+	// 		return nil, status.Error(codes.InvalidArgument, "Volume content source type is set to Snapshot, but the Snapshot is not provided")
 	// 	}
 	// 	snapshotID = snapshot.GetSnapshotId()
 	// }

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -758,14 +758,14 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 		// Todo: Un-comment post client implementation
 		// snapshot, err := d.CivoClient.GetSnapshot(snapshotID)
 		// if err != nil {
-		// Todo: DatabaseSnapshotNotFoundError & DiskSnapshotNotFoundError are placeholders, it's still not clear what error will be returned by API (awaiting implementation - WIP)
-		// if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") ||
-		// 	strings.Contains(err.Error(), "DiskSnapshotNotFoundError") {
-		// 	log.Info().
-		// 		Str("snapshot_id", snapshotID).
-		// 		Msg("ListSnapshots: no snapshot found, returning with success")
-		// 	return &csi.ListSnapshotsResponse{}, nil
-		// }
+		// 	// Todo: DatabaseSnapshotNotFoundError & DiskSnapshotNotFoundError are placeholders, it's still not clear what error will be returned by API (awaiting implementation - WIP)
+		// 	if strings.Contains(err.Error(), "DatabaseSnapshotNotFoundError") ||
+		// 		strings.Contains(err.Error(), "DiskSnapshotNotFoundError") {
+		// 		log.Info().
+		// 			Str("snapshot_id", snapshotID).
+		// 			Msg("ListSnapshots: no snapshot found, returning with success")
+		// 		return &csi.ListSnapshotsResponse{}, nil
+		// 	}
 		// 	log.Error().
 		// 		Err(err).
 		// 		Str("snapshot_id", snapshotID).
@@ -773,7 +773,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshot %q: %v", snapshotID, err)
 		// }
 		// return &csi.ListSnapshotsResponse{
-		//     Entries: []*csi.ListSnapshotsResponse_Entry{convertSnapshot(snapshot)},
+		// 	Entries: []*csi.ListSnapshotsResponse_Entry{convertSnapshot(snapshot)},
 		// }, nil
 	}
 
@@ -784,24 +784,24 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 			Str("source_volume_id", sourceVolumeID).
 			Msg("Fetching volume snapshots")
 
-		// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
-		// if err != nil{
+		// snapshots, err := d.CivoClient.ListSnapshots() // Todo: ListSnapshots to be implemented in civogo
+		// if err != nil {
 		// 	log.Error().
 		// 		Err(err).
 		// 		Str("source_volume_id", sourceVolumeID).
 		// 		Msg("Failed to list snapshots for volume")
-		//     return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %q: %v", sourceVolumeID, err)
+		// 	return nil, status.Errorf(codes.Internal, "failed to list snapshots for volume %q: %v", sourceVolumeID, err)
 		// }
-
+		//
 		// entries := []*csi.ListSnapshotsResponse_Entry{}
 		// for _, snapshot := range snapshots {
-		//     if snapshot.VolID == sourceVolumeID {
-		//         entries = append(entries, convertSnapshot(snapshot))
-		//     }
+		// 	if snapshot.VolID == sourceVolumeID {
+		// 		entries = append(entries, convertSnapshot(snapshot))
+		// 	}
 		// }
-
+		//
 		// return &csi.ListSnapshotsResponse{
-		//     Entries: entries,
+		// 	Entries: entries,
 		// }, nil
 	}
 
@@ -809,27 +809,27 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 
 	// case 3: Retrieve all snapshots if no filters are provided
 	// Todo: un-comment post client(civogo) implementation
-	// snapshots, err := d.CivoClient.ListSnapshots()  // Todo: ListSnapshots to be implemented in civogo
-	// if err != nil{
-	//     log.Error().Err(err).Msg("Failed to list snapshots from Civo API")
-	//     return nil, status.Errorf(codes.Internal, "failed to list snapshots from Civo API: %v", err)
+	// snapshots, err := d.CivoClient.ListSnapshots() // Todo: ListSnapshots to be implemented in civogo
+	// if err != nil {
+	// 	log.Error().Err(err).Msg("Failed to list snapshots from Civo API")
+	// 	return nil, status.Errorf(codes.Internal, "failed to list snapshots from Civo API: %v", err)
 	// }
-
+	//
 	// sort.Slice(snapshots, func(i, j int) bool {
-	//     return snapshots[i].Id < snapshots[j].Id
+	// 	return snapshots[i].Id < snapshots[j].Id
 	// })
-
+	//
 	// entries := []*csi.ListSnapshotsResponse_Entry{}
 	// for _, snap := range snapshots {
-	//     entries = append(entries, convertSnapshot(snap))
+	// 	entries = append(entries, convertSnapshot(snap))
 	// }
-
+	//
 	// log.Info().
 	// 	Int("total_snapshots", len(entries)).
 	// 	Msg("Snapshots listed successfully")
-
+	//
 	// return &csi.ListSnapshotsResponse{
-	//     Entries:   entries,
+	// 	Entries: entries,
 	// }, nil
 	return nil, status.Error(codes.Unimplemented, "")
 }
@@ -852,13 +852,13 @@ func getVolSizeInBytes(capRange *csi.CapacityRange) (int64, error) {
 // Todo: Snapshot to be defined in civogo
 // convertSnapshot function converts a civogo.Snapshot object(API response) into a CSI ListSnapshotsResponse_Entry
 // func convertSnapshot(snap *civogo.Snapshot) *csi.ListSnapshotsResponse_Entry {
-//     return &csi.ListSnapshotsResponse_Entry{
-//         Snapshot: &csi.Snapshot{
-//             SnapshotId:     snap.Id,
-//             SourceVolumeId: snap.VolID,
-//             CreationTime:   snap.CreationTime,
-//             SizeBytes:      snap.SizeBytes,
-//             ReadyToUse:     snap.ReadyToUse,
-//         },
-//     }
+// 	return &csi.ListSnapshotsResponse_Entry{
+// 		Snapshot: &csi.Snapshot{
+// 			SnapshotId:     snap.Id,
+// 			SourceVolumeId: snap.VolID,
+// 			CreationTime:   snap.CreationTime,
+// 			SizeBytes:      snap.SizeBytes,
+// 			ReadyToUse:     snap.ReadyToUse,
+// 		},
+// 	}
 // }

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -106,6 +106,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	// 		return nil, status.Error(codes.InvalidArgument, "Volume content source type is set to Snapshot, but the Snapshot is not provided")
 	// 	}
 	// 	snapshotID = snapshot.GetSnapshotId()
+	// 	if snapshotID == "" {
+	// 		return nil, status.Error(codes.InvalidArgument, "Volume content source type is set to Snapshot, but the SnapshotID is not provided")
+	// 	}
 	// }
 
 	log.Debug().Msg("Volume doesn't currently exist, will need creating")


### PR DESCRIPTION
## WHAT

I have added logic to create volume from volumecontentsource.

## WHY

To support volume snapshot, it is necessary to implement functionality to handle case where a user requests the creation of volume from snapshot using a manifest like the one shown below.

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: csi-pvc-restore
spec:
  dataSource: # <-------------- this 
    name: new-snapshot
    kind: VolumeSnapshot
    apiGroup: snapshot.storage.k8s.io
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: civo-volume
```

## FYI

:warning: The client-side implementation is not yet complete, so some parts are impelemented with comments. Once all the implementations are finished, I will uncomment the code.