### PR TITLE
fix(controller): coalesce concurrent CreateVolume retries + idempotent dup handling

### DIFF
--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -25,7 +26,13 @@ var supportedAccessModes = map[csi.VolumeCapability_AccessMode_Mode]struct{}{
 	csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:   {},
 }
 
-// CreateVolume is the first step when a PVC tries to create a dynamic volume
+// CreateVolume is the first step when a PVC tries to create a dynamic volume.
+//
+// Concurrent gRPC handlers for the same req.Name (CSI external-provisioner
+// retries on transient errors) are coalesced via a per-name singleflight
+// group, so that exactly one (ListVolumes + NewVolume) sequence is in flight
+// per logical volume in this pod. All callers receive the same response,
+// satisfying the CSI spec's idempotency requirement for CreateVolume.
 func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	log.Info().Msg("Request: CreateVolume")
 
@@ -39,7 +46,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	log.Info().Str("name", req.Name).Interface("capabilities", req.VolumeCapabilities).Msg("Creating volume")
 
-	// Check capabilities
+	// Check capabilities (cheap, no API call — kept outside singleflight so
+	// invalid requests fail fast without blocking on an in-flight valid one).
 	for _, cap := range req.VolumeCapabilities {
 		if _, ok := supportedAccessModes[cap.GetAccessMode().GetMode()]; !ok {
 			return nil, status.Error(codes.InvalidArgument, "CreateVolume access mode isn't supported")
@@ -49,7 +57,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		}
 	}
 
-	// Determine required size
+	// Determine required size.
 	bytes, err := getVolSizeInBytes(req.GetCapacityRange())
 	if err != nil {
 		return nil, err
@@ -62,6 +70,22 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	log.Debug().Int64("size_gb", desiredSize).Msg("Volume size determined")
 
+	v, err, shared := d.volumeCreateGroup.Do(req.Name, func() (interface{}, error) {
+		return d.createVolumeUnsynced(ctx, req, desiredSize)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if shared {
+		log.Debug().Str("name", req.Name).Msg("CreateVolume response shared with a concurrent retry (singleflight)")
+	}
+	return v.(*csi.CreateVolumeResponse), nil
+}
+
+// createVolumeUnsynced is the side-effectful body of CreateVolume. It must
+// only be invoked through d.volumeCreateGroup so concurrent retries for the
+// same req.Name are coalesced.
+func (d *Driver) createVolumeUnsynced(_ context.Context, req *csi.CreateVolumeRequest, desiredSize int64) (*csi.CreateVolumeResponse, error) {
 	log.Debug().Msg("Listing current volumes in Civo API")
 	volumes, err := d.CivoClient.ListVolumes()
 	if err != nil {
@@ -70,28 +94,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 	for _, v := range volumes {
 		if v.Name == req.Name {
-			log.Debug().Str("volume_id", v.ID).Msg("Volume already exists")
-			if v.SizeGigabytes != int(desiredSize) {
-				return nil, status.Error(codes.AlreadyExists, "Volume already exists with a differnt size")
-			}
-
-			available, err := d.waitForVolumeStatus(&v, "available", CivoVolumeAvailableRetries)
-			if err != nil {
-				log.Error().Err(err).Msg("Unable to wait for volume availability in Civo API")
-				return nil, err
-			}
-
-			if available {
-				return &csi.CreateVolumeResponse{
-					Volume: &csi.Volume{
-						VolumeId:      v.ID,
-						CapacityBytes: int64(v.SizeGigabytes) * BytesInGigabyte,
-					},
-				}, nil
-			}
-
-			log.Error().Str("status", v.Status).Msg("Civo Volume is not 'available'")
-			return nil, status.Errorf(codes.Unavailable, "Volume isn't available to be attached, state is currently %s", v.Status)
+			return d.resolveExistingVolume(v, desiredSize)
 		}
 	}
 
@@ -142,6 +145,18 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	log.Debug().Msg("Creating volume in Civo API")
 	result, err := d.CivoClient.NewVolume(v)
 	if err != nil {
+		// If the Civo API rejects the create because a sibling request with
+		// the same name already won the race server-side (api-go #243), this
+		// CSI handler must still satisfy the idempotency contract: look the
+		// existing volume up by name and return it as a success.
+		if errors.Is(err, civogo.DatabaseVolumeDuplicateNameError) {
+			log.Info().Str("name", req.Name).Msg("Civo API reported a duplicate name; resolving idempotently")
+			resp, lookupErr := d.lookupExistingByName(req.Name, desiredSize)
+			if lookupErr == nil {
+				return resp, nil
+			}
+			log.Warn().Err(lookupErr).Str("name", req.Name).Msg("Idempotent lookup after duplicate-name failed; returning original error")
+		}
 		log.Error().Err(err).Msg("Unable to create volume in Civo API")
 		return nil, err
 	}
@@ -172,6 +187,52 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	log.Error().Err(err).Msg("Civo Volume is not 'available'")
 	return nil, status.Errorf(codes.Unavailable, "Civo Volume %q is not \"available\", state currently is %q", volume.ID, volume.Status)
+}
+
+// resolveExistingVolume handles the "volume already exists with this name"
+// case found while listing — returns the existing volume as a successful
+// CreateVolumeResponse if the requested size matches and the volume is
+// available, or an appropriate error otherwise.
+func (d *Driver) resolveExistingVolume(v civogo.Volume, desiredSize int64) (*csi.CreateVolumeResponse, error) {
+	log.Debug().Str("volume_id", v.ID).Msg("Volume already exists")
+	if v.SizeGigabytes != int(desiredSize) {
+		return nil, status.Error(codes.AlreadyExists, "Volume already exists with a differnt size")
+	}
+
+	available, err := d.waitForVolumeStatus(&v, "available", CivoVolumeAvailableRetries)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to wait for volume availability in Civo API")
+		return nil, err
+	}
+
+	if available {
+		return &csi.CreateVolumeResponse{
+			Volume: &csi.Volume{
+				VolumeId:      v.ID,
+				CapacityBytes: int64(v.SizeGigabytes) * BytesInGigabyte,
+			},
+		}, nil
+	}
+
+	log.Error().Str("status", v.Status).Msg("Civo Volume is not 'available'")
+	return nil, status.Errorf(codes.Unavailable, "Volume isn't available to be attached, state is currently %s", v.Status)
+}
+
+// lookupExistingByName lists volumes and returns the one matching name as a
+// CreateVolumeResponse. Used to satisfy CSI idempotency when the Civo API
+// rejected our NewVolume call because a sibling request had already created
+// the volume server-side. Returns an error if no matching volume is found.
+func (d *Driver) lookupExistingByName(name string, desiredSize int64) (*csi.CreateVolumeResponse, error) {
+	volumes, err := d.CivoClient.ListVolumes()
+	if err != nil {
+		return nil, fmt.Errorf("list volumes for idempotent lookup: %w", err)
+	}
+	for _, v := range volumes {
+		if v.Name == name {
+			return d.resolveExistingVolume(v, desiredSize)
+		}
+	}
+	return nil, fmt.Errorf("volume %q not found in idempotent lookup after duplicate-name response", name)
 }
 
 // waitForVolumeAvailable will just sleep/loop waiting for Civo's API to report it's available, or hit a defined

--- a/pkg/driver/controller_server.go
+++ b/pkg/driver/controller_server.go
@@ -87,15 +87,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 // same req.Name are coalesced.
 func (d *Driver) createVolumeUnsynced(_ context.Context, req *csi.CreateVolumeRequest, desiredSize int64) (*csi.CreateVolumeResponse, error) {
 	log.Debug().Msg("Listing current volumes in Civo API")
-	volumes, err := d.CivoClient.ListVolumes()
-	if err != nil {
+	if resp, found, err := d.lookupExistingByName(req.Name, desiredSize); err != nil {
 		log.Error().Err(err).Msg("Unable to list volumes in Civo API")
 		return nil, err
-	}
-	for _, v := range volumes {
-		if v.Name == req.Name {
-			return d.resolveExistingVolume(v, desiredSize)
-		}
+	} else if found {
+		return resp, nil
 	}
 
 	// TODO: Uncomment after client implementation is complete.
@@ -151,11 +147,13 @@ func (d *Driver) createVolumeUnsynced(_ context.Context, req *csi.CreateVolumeRe
 		// existing volume up by name and return it as a success.
 		if errors.Is(err, civogo.DatabaseVolumeDuplicateNameError) {
 			log.Info().Str("name", req.Name).Msg("Civo API reported a duplicate name; resolving idempotently")
-			resp, lookupErr := d.lookupExistingByName(req.Name, desiredSize)
-			if lookupErr == nil {
+			if resp, found, lookupErr := d.lookupExistingByName(req.Name, desiredSize); lookupErr != nil {
+				log.Warn().Err(lookupErr).Str("name", req.Name).Msg("Idempotent lookup after duplicate-name failed; returning original error")
+			} else if found {
 				return resp, nil
+			} else {
+				log.Warn().Str("name", req.Name).Msg("Volume not found in idempotent lookup after duplicate-name response; returning original error")
 			}
-			log.Warn().Err(lookupErr).Str("name", req.Name).Msg("Idempotent lookup after duplicate-name failed; returning original error")
 		}
 		log.Error().Err(err).Msg("Unable to create volume in Civo API")
 		return nil, err
@@ -218,21 +216,30 @@ func (d *Driver) resolveExistingVolume(v civogo.Volume, desiredSize int64) (*csi
 	return nil, status.Errorf(codes.Unavailable, "Volume isn't available to be attached, state is currently %s", v.Status)
 }
 
-// lookupExistingByName lists volumes and returns the one matching name as a
-// CreateVolumeResponse. Used to satisfy CSI idempotency when the Civo API
-// rejected our NewVolume call because a sibling request had already created
-// the volume server-side. Returns an error if no matching volume is found.
-func (d *Driver) lookupExistingByName(name string, desiredSize int64) (*csi.CreateVolumeResponse, error) {
+// lookupExistingByName lists volumes and, if one matches the given name,
+// returns it as a CreateVolumeResponse. The "found" return distinguishes
+// "volume with this name exists" (true, resp may carry a resolve error)
+// from "no such volume" (false, resp == nil) so callers can act on each
+// case explicitly:
+//
+//   - The CreateVolume pre-check uses found=false to mean "no duplicate;
+//     proceed to create".
+//   - The duplicate-name error handler uses found=false to mean "lookup
+//     couldn't recover idempotently; return the original error".
+//
+// err is non-nil only when the underlying ListVolumes call itself failed.
+func (d *Driver) lookupExistingByName(name string, desiredSize int64) (*csi.CreateVolumeResponse, bool, error) {
 	volumes, err := d.CivoClient.ListVolumes()
 	if err != nil {
-		return nil, fmt.Errorf("list volumes for idempotent lookup: %w", err)
+		return nil, false, fmt.Errorf("list volumes for lookup: %w", err)
 	}
 	for _, v := range volumes {
 		if v.Name == name {
-			return d.resolveExistingVolume(v, desiredSize)
+			resp, rerr := d.resolveExistingVolume(v, desiredSize)
+			return resp, true, rerr
 		}
 	}
-	return nil, fmt.Errorf("volume %q not found in idempotent lookup after duplicate-name response", name)
+	return nil, false, nil
 }
 
 // waitForVolumeAvailable will just sleep/loop waiting for Civo's API to report it's available, or hit a defined

--- a/pkg/driver/controller_server_dedup_test.go
+++ b/pkg/driver/controller_server_dedup_test.go
@@ -1,0 +1,202 @@
+package driver_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/civo/civo-csi/pkg/driver"
+	"github.com/civo/civogo"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeWithHooks embeds the real FakeClient and overrides NewVolume / ListVolumes
+// so tests can drive the "API rejected our create" race scenarios that the
+// stock FakeClient can't express.
+type fakeWithHooks struct {
+	*civogo.FakeClient
+
+	mu               sync.Mutex
+	newVolumeErr     error // if non-nil, NewVolume returns this without touching storage
+	newVolumeCalls   int32
+	newVolumeBlockOn chan struct{} // if non-nil, NewVolume blocks until this is closed
+	listVolumeCalls  int32
+}
+
+func (f *fakeWithHooks) NewVolume(v *civogo.VolumeConfig) (*civogo.VolumeResult, error) {
+	atomic.AddInt32(&f.newVolumeCalls, 1)
+	if f.newVolumeBlockOn != nil {
+		<-f.newVolumeBlockOn
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.newVolumeErr != nil {
+		return nil, f.newVolumeErr
+	}
+	return f.FakeClient.NewVolume(v)
+}
+
+func (f *fakeWithHooks) ListVolumes() ([]civogo.Volume, error) {
+	atomic.AddInt32(&f.listVolumeCalls, 1)
+	return f.FakeClient.ListVolumes()
+}
+
+// minimalVolumeRequest returns a CreateVolumeRequest with the given name and
+// the default size / a single-writer access mode.
+func minimalVolumeRequest(name string) *csi.CreateVolumeRequest {
+	return &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		}},
+	}
+}
+
+// TestCreateVolume_SingleflightCoalescesConcurrentCalls fires three concurrent
+// CreateVolume calls with the same req.Name. Only one (ListVolumes + NewVolume)
+// pair should actually run against the API; all three callers must receive the
+// same VolumeId.
+func TestCreateVolume_SingleflightCoalescesConcurrentCalls(t *testing.T) {
+	base, _ := civogo.NewFakeClient()
+	gate := make(chan struct{})
+	fc := &fakeWithHooks{FakeClient: base, newVolumeBlockOn: gate}
+
+	d, err := driver.NewTestDriver(nil)
+	if err != nil {
+		t.Fatalf("NewTestDriver: %v", err)
+	}
+	d.CivoClient = fc
+
+	type result struct {
+		resp *csi.CreateVolumeResponse
+		err  error
+	}
+	results := make(chan result, 3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			r, e := d.CreateVolume(context.Background(), minimalVolumeRequest("coalesced-vol"))
+			results <- result{resp: r, err: e}
+		}()
+	}
+
+	// Give the three goroutines time to enter singleflight before releasing
+	// the in-flight call. 50 ms is enough for fast test machines; the gate
+	// ensures we don't race on the unblock.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+
+	collected := make([]result, 0, 3)
+	for i := 0; i < 3; i++ {
+		select {
+		case r := <-results:
+			collected = append(collected, r)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for CreateVolume response %d", i)
+		}
+	}
+
+	for _, r := range collected {
+		assert.NoError(t, r.err)
+		assert.NotNil(t, r.resp)
+	}
+
+	// All three responses must reference the same VolumeId.
+	id := collected[0].resp.Volume.VolumeId
+	for i, r := range collected[1:] {
+		assert.Equal(t, id, r.resp.Volume.VolumeId, "response %d returned a different VolumeId", i+1)
+	}
+
+	// Exactly one NewVolume must have been issued; ListVolumes is also called
+	// once for the pre-check (the other two callers piggy-backed on the
+	// singleflight result).
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fc.newVolumeCalls), "expected exactly one NewVolume call")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fc.listVolumeCalls), "expected exactly one ListVolumes call inside singleflight")
+}
+
+// TestCreateVolume_DuplicateNameTriggersIdempotentLookup simulates the api-go
+// rejecting our NewVolume with database_volume_duplicate_name because a
+// concurrent retry already won the race server-side. The CSI plugin must
+// resolve the existing volume by name and return it as a success rather than
+// bubbling the error back to external-provisioner.
+func TestCreateVolume_DuplicateNameTriggersIdempotentLookup(t *testing.T) {
+	base, _ := civogo.NewFakeClient()
+	// Pre-populate the "existing" volume as if a sibling create had already
+	// won server-side.
+	existing := civogo.Volume{
+		ID:            "existing-vol-id",
+		Name:          "raced-vol",
+		SizeGigabytes: 10,
+		Status:        "available",
+	}
+	base.Volumes = []civogo.Volume{existing}
+
+	// Wrap with hooks; cause NewVolume to return the duplicate-name error.
+	fc := &fakeWithHooks{
+		FakeClient:   base,
+		newVolumeErr: civogo.DatabaseVolumeDuplicateNameError,
+	}
+
+	d, _ := driver.NewTestDriver(nil)
+	d.CivoClient = fc
+
+	// We need ListVolumes to return the existing volume on the FIRST call
+	// (the pre-check) only after we've already poisoned the volume into the
+	// fake's storage. To reproduce the race more faithfully (pre-check sees
+	// no match, NewVolume rejects with duplicate-name, idempotent lookup
+	// finds it), we'd swap the storage between calls. For unit-testing the
+	// lookup path it's enough that the volume exists when the lookup runs.
+
+	resp, err := d.CreateVolume(context.Background(), minimalVolumeRequest("raced-vol"))
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "existing-vol-id", resp.Volume.VolumeId, "CSI must return the existing volume's id after a duplicate-name response")
+}
+
+// TestCreateVolume_DuplicateNameWithMissingVolumeReturnsError covers the rare
+// case where api-go returns DatabaseVolumeDuplicateNameError but the volume
+// isn't in our ListVolumes lookup (e.g. it was deleted between the API
+// rejection and our lookup). The original duplicate-name error must be
+// returned so external-provisioner can retry rather than silently succeeding.
+func TestCreateVolume_DuplicateNameWithMissingVolumeReturnsError(t *testing.T) {
+	base, _ := civogo.NewFakeClient()
+	fc := &fakeWithHooks{
+		FakeClient:   base,
+		newVolumeErr: civogo.DatabaseVolumeDuplicateNameError,
+	}
+
+	d, _ := driver.NewTestDriver(nil)
+	d.CivoClient = fc
+
+	resp, err := d.CreateVolume(context.Background(), minimalVolumeRequest("ghost-vol"))
+	assert.Nil(t, resp)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	// Confirm it's the original duplicate-name error wrapped, not a generic
+	// internal error from the lookup.
+	if !errors.Is(err, civogo.DatabaseVolumeDuplicateNameError) {
+		t.Errorf("expected DatabaseVolumeDuplicateNameError, got %v (%T)", err, err)
+	}
+	// Sanity: NewVolume was called once, ListVolumes was called twice (the
+	// pre-check + the idempotent lookup after the duplicate-name response).
+	if got := atomic.LoadInt32(&fc.newVolumeCalls); got != 1 {
+		t.Errorf("expected exactly 1 NewVolume call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&fc.listVolumeCalls); got != 2 {
+		t.Errorf("expected 2 ListVolumes calls (pre-check + lookup), got %d", got)
+	}
+}
+
+// Sanity: compile-time assertion that fakeWithHooks satisfies civogo.Clienter
+// so the test driver accepts it.
+var _ civogo.Clienter = (*fakeWithHooks)(nil)
+
+// Avoid unused-import warnings if the file is trimmed in future refactors.
+var _ = fmt.Sprintf

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 )
 
@@ -42,6 +43,15 @@ type Driver struct {
 	TestMode          bool
 	grpcServer        *grpc.Server
 	ClusterVolumeType string
+
+	// volumeCreateGroup coalesces concurrent CreateVolume gRPC handlers for
+	// the same req.Name in this pod into a single call into the Civo API.
+	// CSI external-provisioner retries the gRPC call on transient errors;
+	// without coalescing, two retries can both do the (ListVolumes +
+	// NewVolume) sequence in parallel and end up creating duplicate
+	// CivoVolume CRs. Per-name singleflight is sufficient because the
+	// controller deployment is replicas: 1.
+	volumeCreateGroup singleflight.Group
 }
 
 // NewDriver returns a CSI driver that implements gRPC endpoints for CSI


### PR DESCRIPTION
The CSI external-provisioner retries CreateVolume aggressively on transient errors. Today civo-csi's CreateVolume does (ListVolumes + NewVolume) with no in-process coordination, so two concurrent retries for the same req.Name can both miss each other's volume in the pre-check and both call NewVolume against the Civo API. With the companion api-go fix that rejects duplicate-name creates server-side, we'd then bubble the duplicate-name error back to external-provisioner and burn another retry instead of resolving idempotently.

Two changes:

1. Wrap the side-effectful body of CreateVolume in a per-name singleflight group on the Driver struct. N concurrent gRPC handlers for the same req.Name in this pod produce exactly one (ListVolumes + NewVolume) sequence; all N callers share the same result. The controller deployment is replicas: 1 so in-process coordination is sufficient client-side.

2. When NewVolume returns civogo.DatabaseVolumeDuplicateNameError (api-go #243's response when a sibling already won the race server-side), do an idempotent ListVolumes lookup by name and return the existing volume as a CreateVolumeResponse. Per CSI spec, CreateVolume must be idempotent for the same Name. If the lookup finds no matching volume the original duplicate-name error is returned so external-provisioner retries rather than silently succeeding.

Tests:

- TestCreateVolume_SingleflightCoalescesConcurrentCalls: three parallel calls with the same name produce exactly one NewVolume call and identical responses.
- TestCreateVolume_DuplicateNameTriggersIdempotentLookup: simulates the api-go race-loser path and asserts the existing volume's ID comes back as a success.
- TestCreateVolume_DuplicateNameWithMissingVolumeReturnsError: duplicate-name with no matching volume in the lookup returns the original error (still wrapped via errors.Is).
