### PR TITLE
fix(node): unmount staging target path in NodeUnstageVolume

### DIFF
--- a/pkg/driver/node_server.go
+++ b/pkg/driver/node_server.go
@@ -88,23 +88,20 @@ func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolu
 	}
 
 	log.Debug().Str("volume_id", req.VolumeId).Str("path", req.StagingTargetPath).Msg("Unmounting volume (unstaging)")
-	path := d.DiskHotPlugger.PathForVolume(req.VolumeId)
 
-	if path == "" && !d.TestMode {
-		log.Error().Str("volume_id", req.VolumeId).Msg("path to volume (/dev/disk/by-id/VOLUME_ID) not found")
-		return &csi.NodeUnstageVolumeResponse{}, nil
-	}
-
-	mounted, err := d.DiskHotPlugger.IsMounted(path)
+	mounted, err := d.DiskHotPlugger.IsMounted(req.StagingTargetPath)
 	if err != nil {
-		log.Error().Str("path", path).Err(err).Msg("Mounted check errored")
+		log.Error().Str("path", req.StagingTargetPath).Err(err).Msg("Mounted check errored")
 		return nil, err
 	}
 	log.Debug().Str("volume_id", req.VolumeId).Bool("mounted", mounted).Msg("Mounted check completed")
 
 	if mounted {
 		log.Debug().Str("volume_id", req.VolumeId).Bool("mounted", mounted).Msg("Unmounting")
-		d.DiskHotPlugger.Unmount(path)
+		if err := d.DiskHotPlugger.Unmount(req.StagingTargetPath); err != nil {
+			log.Error().Str("path", req.StagingTargetPath).Err(err).Msg("Failed to unmount staging target path")
+			return nil, err
+		}
 	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil

--- a/pkg/driver/node_server_test.go
+++ b/pkg/driver/node_server_test.go
@@ -88,13 +88,15 @@ func TestNodeStageVolume(t *testing.T) {
 }
 
 func TestNodeUnstageVolume(t *testing.T) {
-	t.Run("Unmount the volume", func(t *testing.T) {
+	t.Run("Unmounts the volume from the staging target path", func(t *testing.T) {
 		fc, _ := civogo.NewFakeClient()
 		d, _ := driver.NewTestDriver(fc)
 
+		// Represents a volume already staged (mounted) at the staging target path
 		hotPlugger := &driver.FakeDiskHotPlugger{
-			Formatted: true,
-			Mounted:   true,
+			Formatted:  true,
+			Mounted:    true,
+			Mountpoint: "/mnt/my-target",
 		}
 		d.DiskHotPlugger = hotPlugger
 
@@ -104,6 +106,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 		})
 		assert.Nil(t, err)
 
+		assert.False(t, hotPlugger.Mounted)
 		mounted, _ := d.DiskHotPlugger.IsMounted("/mnt/my-target")
 		assert.False(t, mounted)
 	})


### PR DESCRIPTION
## Problem

`NodeUnstageVolume` checked and unmounted the **device path** (`PathForVolume` → `/dev/disk/by-id/VOLUME_ID`) instead of `req.StagingTargetPath`, which is what `NodeStageVolume` actually mounts.

`RealDiskHotPlugger.IsMounted` uses `findmnt -M <path>`, where `-M` treats its argument as a *mountpoint*. A device path is never a mountpoint, so the check always returned `false`, the `if mounted` block was skipped, and **`Unmount` was never called on real nodes**.

Consequences if left unfixed:

- 🔴 The staging mount is never removed, so the disk can be detached (via `ControllerUnpublishVolume`) while still mounted → unflushed writes lost / filesystem corruption risk.
- 🟡 Staging mounts (`globalmount`) leak and accumulate on nodes.
- Additionally, the `Unmount` return value was **discarded**, so a real unmount failure (e.g. `device busy`) was still reported as success.

The bug was silent: the RPC always returned success, and the existing test passed vacuously (`Mountpoint` never set), so CI could not catch it.

## Fix

- Check/unmount `req.StagingTargetPath` (symmetric with `NodeStageVolume` / `NodeUnpublishVolume`).
- Propagate the `Unmount` error instead of discarding it.
- Drop the now-unnecessary device-path lookup and `TestMode` branch (`TestMode` remains used elsewhere).

## Test

Reworked `TestNodeUnstageVolume` to represent an actually-staged volume (`Mountpoint` set) and assert the unmount happens. Verified it **fails on the old code** (RED) and **passes on the fixed code** (GREEN).

`go build ./...`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)